### PR TITLE
Improve push event subscription update when send event to client

### DIFF
--- a/src/main/java/com/clouway/push/client/EventDispatcher.java
+++ b/src/main/java/com/clouway/push/client/EventDispatcher.java
@@ -1,0 +1,15 @@
+package com.clouway.push.client;
+
+import com.clouway.push.shared.HandlerRegistration;
+import com.clouway.push.shared.PushEvent;
+import com.clouway.push.shared.PushEventHandler;
+
+/**
+ * @author Georgi Georgiev (GeorgievJon@gmail.com)
+ */
+public interface EventDispatcher {
+
+  HandlerRegistration addHandler(PushEvent.Type type, PushEventHandler handler);
+
+  void fire(PushEvent event);
+}

--- a/src/main/java/com/clouway/push/client/EventDispatcherImpl.java
+++ b/src/main/java/com/clouway/push/client/EventDispatcherImpl.java
@@ -1,0 +1,57 @@
+package com.clouway.push.client;
+
+import com.clouway.push.shared.HandlerRegistration;
+import com.clouway.push.shared.PushEvent;
+import com.clouway.push.shared.PushEventHandler;
+import com.google.common.collect.Lists;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Georgi Georgiev (GeorgievJon@gmail.com)
+ */
+public class EventDispatcherImpl implements EventDispatcher {
+
+  private Map<String, List<PushEventHandler>> handlerMap = new HashMap<String, List<PushEventHandler>>();
+
+  @Override
+  public HandlerRegistration addHandler(PushEvent.Type type, final PushEventHandler handler) {
+    final String key = type.getKey();
+
+    if(handlerMap.containsKey(key)) {
+      List<PushEventHandler> handlers = handlerMap.get(key);
+      handlers.add(handler);
+    } else {
+      handlerMap.put(type.getKey(), Lists.newArrayList(handler));
+    }
+
+    return new HandlerRegistration() {
+      @Override
+      public void removeHandler() {
+        if(handlerMap.containsKey(key)) {
+          List<PushEventHandler> handlers = handlerMap.get(key);
+          handlers.remove(handler);
+
+          if(handlers.isEmpty()) {
+            handlerMap.remove(key);
+          }
+        }
+      }
+    };
+  }
+
+  @Override
+  public void fire(PushEvent event) {
+    String key = event.getAssociatedType().getKey();
+
+    if(handlerMap.containsKey(key)) {
+      List<PushEventHandler> handlers = handlerMap.get(key);
+
+      for (PushEventHandler handler : handlers) {
+        event.dispatch(handler);
+      }
+    }
+  }
+}

--- a/src/main/java/com/clouway/push/client/PushChannelGinModule.java
+++ b/src/main/java/com/clouway/push/client/PushChannelGinModule.java
@@ -5,14 +5,11 @@ import com.clouway.push.client.channelapi.ChannelImpl;
 import com.clouway.push.client.channelapi.PushChannelService;
 import com.clouway.push.client.channelapi.PushChannelServiceAsync;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.shared.EventBus;
-import com.google.gwt.event.shared.SimpleEventBus;
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.user.client.rpc.ServiceDefTarget;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.google.inject.name.Names;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +25,7 @@ class PushChannelGinModule extends AbstractGinModule {
 
     bind(PushChannelApi.class).to(PushChannelApiImpl.class).in(Singleton.class);
     bind(PushEventBus.class).to(ChannelApiPushEventBus.class).in(Singleton.class);
-    bind(EventBus.class).annotatedWith(Names.named("PushEventBus")).to(SimpleEventBus.class).in(Singleton.class);
+    bind(EventDispatcher.class).to(EventDispatcherImpl.class).in(Singleton.class);
     bind(Channel.class).to(ChannelImpl.class).in(Singleton.class);
   }
 

--- a/src/main/java/com/clouway/push/client/PushEventBus.java
+++ b/src/main/java/com/clouway/push/client/PushEventBus.java
@@ -1,8 +1,8 @@
 package com.clouway.push.client;
 
+import com.clouway.push.shared.HandlerRegistration;
 import com.clouway.push.shared.PushEvent;
 import com.clouway.push.shared.PushEventHandler;
-import com.google.web.bindery.event.shared.HandlerRegistration;
 
 /**
  * @author Ivan Lazov <ivan.lazov@clouway.com>
@@ -10,4 +10,8 @@ import com.google.web.bindery.event.shared.HandlerRegistration;
 public interface PushEventBus {
 
   HandlerRegistration addHandler(final PushEvent.Type type, final PushEventHandler handler);
+
+  HandlerRegistration addHandler(final PushEvent.Type type,final String correlationId, final PushEventHandler handler);
+
+  void fireEvent(PushEvent event);
 }

--- a/src/main/java/com/clouway/push/server/ActiveSubscriptionsFilterImpl.java
+++ b/src/main/java/com/clouway/push/server/ActiveSubscriptionsFilterImpl.java
@@ -3,10 +3,12 @@ package com.clouway.push.server;
 import com.clouway.push.shared.PushEvent;
 import com.clouway.push.shared.util.DateTime;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Ivan Lazov <ivan.lazov@clouway.com>
@@ -29,13 +31,17 @@ public class ActiveSubscriptionsFilterImpl implements ActiveSubscriptionsFilter 
 
     List<Subscription> subscriptions = subscriptionsRepository.findSubscriptions(type);
 
+    Set<String> subscribersForRemove = Sets.newHashSet();
+
     for (Subscription subscription : subscriptions) {
       if(subscription.isActive(currentDate.get())){
         activeSubscriptions.add(subscription);
       }else {
-        subscriptionsRepository.removeSubscription(subscription);
+        subscribersForRemove.add(subscription.getSubscriber());
       }
     }
+
+    subscriptionsRepository.removeSubscriptions(type, subscribersForRemove);
 
     return activeSubscriptions;
   }

--- a/src/main/java/com/clouway/push/server/MemcacheSubscriptionsRepository.java
+++ b/src/main/java/com/clouway/push/server/MemcacheSubscriptionsRepository.java
@@ -1,27 +1,36 @@
 package com.clouway.push.server;
 
 import com.clouway.push.shared.PushEvent;
+import com.google.appengine.api.memcache.Expiration;
 import com.google.appengine.api.memcache.MemcacheService;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.google.inject.name.Named;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
 
 import static com.clouway.push.server.Subscription.aNewSubscription;
 
 /**
  * @author Ivan Lazov <ivan.lazov@clouway.com>
  */
-public class MemcachSubscriptionsRepository implements SubscriptionsRepository {
+public class MemcacheSubscriptionsRepository implements SubscriptionsRepository {
+
+  private static final Logger log = Logger.getLogger(MemcacheSubscriptionsRepository.class.getName());
 
   private final MemcacheService memcacheService;
+  private Provider<Integer> subscriptionsExpiration;
 
   @Inject
-  public MemcachSubscriptionsRepository(@Named("MemcacheService") MemcacheService memcacheService) {
+  public MemcacheSubscriptionsRepository(@Named("MemcacheService") MemcacheService memcacheService,
+                                         @SubscriptionsExpirationMills Provider<Integer> subscriptionsExpiration) {
     this.memcacheService = memcacheService;
+    this.subscriptionsExpiration = subscriptionsExpiration;
   }
 
   @Override
@@ -29,7 +38,7 @@ public class MemcachSubscriptionsRepository implements SubscriptionsRepository {
 
     Map<String, Subscription> subscriptionsMap = fetchSubscriptions(subscriber);
 
-    return subscriptionsMap != null && subscriptionsMap.containsKey(eventType.getEventName());
+    return subscriptionsMap != null && subscriptionsMap.containsKey(eventType.getKey());
   }
 
   @Override
@@ -72,6 +81,19 @@ public class MemcachSubscriptionsRepository implements SubscriptionsRepository {
   }
 
   @Override
+  public void removeSubscriptions(PushEvent.Type type, Set<String> subscribers) {
+    Map<String, Subscription> subscriptions = fetchSubscriptions(type);
+
+    for (String subscriber : subscribers) {
+      subscriptions.remove(subscriber);
+    }
+
+    if(!subscribers.isEmpty()) {
+      storeSubscriptions(type, subscriptions);
+    }
+  }
+
+  @Override
   public List<Subscription> findSubscriptions(String subscriber) {
 
     Map<String, Subscription> subscriptions = fetchSubscriptions(subscriber);
@@ -85,7 +107,9 @@ public class MemcachSubscriptionsRepository implements SubscriptionsRepository {
   @Override
   public List<Subscription> findSubscriptions(PushEvent.Type type) {
 
-    Map<String, Subscription> subscriptions = (Map<String, Subscription>) memcacheService.get(type.getEventName());
+    log.info("Event type: " + type.getKey());
+
+    Map<String, Subscription> subscriptions = (Map<String, Subscription>) memcacheService.get(type.getKey());
 
     if (subscriptions != null) {
       return Lists.newArrayList(subscriptions.values());
@@ -127,16 +151,16 @@ public class MemcachSubscriptionsRepository implements SubscriptionsRepository {
   }
 
   private void storeSubscriptions(PushEvent.Type type, Map<String, Subscription> subscriptionMap) {
-    safeStore(type.getEventName(), subscriptionMap);
+    safeStore(type.getKey(), subscriptionMap);
   }
 
   private void safeStore(String key, Map<String, Subscription> subscriptionMap) {
 
     MemcacheService.IdentifiableValue identifiableValue = memcacheService.getIdentifiable(key);
     if (identifiableValue != null) {
-      memcacheService.putIfUntouched(key, identifiableValue, subscriptionMap);
+      memcacheService.putIfUntouched(key, identifiableValue, subscriptionMap, Expiration.byDeltaMillis(subscriptionsExpiration.get()));
     } else {
-      memcacheService.put(key, subscriptionMap);
+      memcacheService.put(key, subscriptionMap, Expiration.byDeltaMillis(subscriptionsExpiration.get()));
     }
   }
 
@@ -145,7 +169,7 @@ public class MemcachSubscriptionsRepository implements SubscriptionsRepository {
   }
 
   private Map<String, Subscription> fetchSubscriptions(PushEvent.Type type) {
-    return safeGet(type.getEventName());
+    return safeGet(type.getKey());
   }
 
   private Map<String, Subscription> safeGet(String key) {

--- a/src/main/java/com/clouway/push/server/PushChannelModule.java
+++ b/src/main/java/com/clouway/push/server/PushChannelModule.java
@@ -30,7 +30,7 @@ public class PushChannelModule extends AbstractModule {
 
     bind(PushService.class).to(PushServiceImpl.class).in(Singleton.class);
     bind(String.class).annotatedWith(Names.named("SerializationPolicyDirectory")).toInstance(serializationPolicyDirectory);
-    bind(SubscriptionsRepository.class).to(MemcachSubscriptionsRepository.class);
+    bind(SubscriptionsRepository.class).to(MemcacheSubscriptionsRepository.class);
 
     install(new ServletModule() {
       @Override
@@ -44,6 +44,12 @@ public class PushChannelModule extends AbstractModule {
   @SubscriptionsExpirationDate
   DateTime getSubscriptionExpirationDate() {
     return new DateTime().plusMills(subscriptionsExpirationMinutes * 60 * 1000);
+  }
+
+  @Provides
+  @SubscriptionsExpirationMills
+  Integer getSubscriptionExpirationMills() {
+    return subscriptionsExpirationMinutes * 60 * 1000;
   }
 
   @Provides

--- a/src/main/java/com/clouway/push/server/PushChannelServiceImpl.java
+++ b/src/main/java/com/clouway/push/server/PushChannelServiceImpl.java
@@ -43,9 +43,9 @@ public class PushChannelServiceImpl extends RemoteServiceServlet implements Push
   @Override
   public void subscribe(String subscriber, PushEvent.Type type) {
 
-    log.info("Subscribe: " + subscriber + " for event: " + type.getEventName());
+    log.info("Subscribe: " + subscriber + " for event: " + type.getKey());
 
-    Subscription subscription = aNewSubscription().eventName(type.getEventName())
+    Subscription subscription = aNewSubscription().eventName(type.getKey())
                                                   .eventType(type)
                                                   .subscriber(subscriber)
                                                   .expirationDate(expirationDate.get())
@@ -57,7 +57,7 @@ public class PushChannelServiceImpl extends RemoteServiceServlet implements Push
   @Override
   public void unsubscribe(String subscriber, PushEvent.Type eventType) {
 
-    log.info("Unsubscribe: " + subscriber + " from event: " + eventType.getEventName());
+    log.info("Unsubscribe: " + subscriber + " from event: " + eventType.getKey());
 
     if (subscriptionsRepository.hasSubscription(eventType, subscriber)) {
       subscriptionsRepository.removeSubscription(eventType, subscriber);

--- a/src/main/java/com/clouway/push/server/PushService.java
+++ b/src/main/java/com/clouway/push/server/PushService.java
@@ -8,4 +8,6 @@ import com.clouway.push.shared.PushEvent;
 public interface PushService {
 
   void pushEvent(PushEvent event);
+
+  void pushEvent(PushEvent event, String correlationId);
 }

--- a/src/main/java/com/clouway/push/server/Subscription.java
+++ b/src/main/java/com/clouway/push/server/Subscription.java
@@ -39,7 +39,7 @@ public class Subscription implements Serializable {
 
     public Builder eventType(PushEvent.Type type) {
       this.type = type;
-      eventName = type.getEventName();
+      eventName = type.getKey();
       return this;
     }
 

--- a/src/main/java/com/clouway/push/server/SubscriptionsExpirationMills.java
+++ b/src/main/java/com/clouway/push/server/SubscriptionsExpirationMills.java
@@ -1,0 +1,17 @@
+package com.clouway.push.server;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Ivan Lazov <ivan.lazov@clouway.com>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@BindingAnnotation
+public @interface SubscriptionsExpirationMills {
+}

--- a/src/main/java/com/clouway/push/server/SubscriptionsRepository.java
+++ b/src/main/java/com/clouway/push/server/SubscriptionsRepository.java
@@ -3,6 +3,7 @@ package com.clouway.push.server;
 import com.clouway.push.shared.PushEvent;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Ivan Lazov <ivan.lazov@clouway.com>
@@ -14,6 +15,8 @@ public interface SubscriptionsRepository {
   void put(Subscription subscription);
 
   void removeSubscription(PushEvent.Type eventType, String subscriber);
+
+  void removeSubscriptions(PushEvent.Type type, Set<String> subscribers);
 
   List<Subscription> findSubscriptions(String subscriber);
 

--- a/src/main/java/com/clouway/push/shared/HandlerRegistration.java
+++ b/src/main/java/com/clouway/push/shared/HandlerRegistration.java
@@ -1,0 +1,10 @@
+package com.clouway.push.shared;
+
+/**
+ * @author Georgi Georgiev (GeorgievJon@gmail.com)
+ */
+public interface HandlerRegistration {
+
+  void removeHandler();
+
+}

--- a/src/main/java/com/clouway/push/shared/PushEvent.java
+++ b/src/main/java/com/clouway/push/shared/PushEvent.java
@@ -1,26 +1,23 @@
 package com.clouway.push.shared;
 
-import com.google.web.bindery.event.shared.Event;
-
 import java.io.Serializable;
 
 /**
  * @author Ivan Lazov <ivan.lazov@clouway.com>
  */
-public abstract class PushEvent<T extends PushEventHandler> extends Event<T> implements Serializable {
+public abstract class PushEvent<T extends PushEventHandler>  implements Serializable {
 
   protected PushEvent() {
   }
 
-  @Override
   public abstract Type<T> getAssociatedType();
 
-  @Override
   public abstract void dispatch(T handler);
 
-  public static class Type<T> extends Event.Type<T> implements Serializable {
+  public static class Type<T> implements Serializable {
 
     private String eventName;
+    private String correlationId = "";
 
     public Type() {
     }
@@ -29,8 +26,40 @@ public abstract class PushEvent<T extends PushEventHandler> extends Event<T> imp
       this.eventName = eventName;
     }
 
-    public String getEventName() {
-      return eventName;
+    public Type(String eventName, String correlationId) {
+      this.eventName = eventName;
+      this.correlationId = correlationId;
+    }
+
+    public String getKey() {
+      return eventName + correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+      if(correlationId == null) {
+        correlationId = "";
+      }
+      this.correlationId = correlationId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Type type = (Type) o;
+
+      if (correlationId != null ? !correlationId.equals(type.correlationId) : type.correlationId != null) return false;
+      if (eventName != null ? !eventName.equals(type.eventName) : type.eventName != null) return false;
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = eventName != null ? eventName.hashCode() : 0;
+      result = 31 * result + (correlationId != null ? correlationId.hashCode() : 0);
+      return result;
     }
   }
 }

--- a/src/main/java/com/clouway/push/shared/PushEventHandler.java
+++ b/src/main/java/com/clouway/push/shared/PushEventHandler.java
@@ -1,9 +1,7 @@
 package com.clouway.push.shared;
 
-import com.google.gwt.event.shared.EventHandler;
-
 /**
  * @author Ivan Lazov <ivan.lazov@clouway.com>
  */
-public interface PushEventHandler extends EventHandler {
+public interface PushEventHandler {
 }

--- a/src/test/java/com/clouway/push/server/ActiveSubscriptionsFilterImplTest.java
+++ b/src/test/java/com/clouway/push/server/ActiveSubscriptionsFilterImplTest.java
@@ -3,6 +3,7 @@ package com.clouway.push.server;
 import com.clouway.push.shared.PushEvent;
 import com.clouway.push.shared.PushEventHandler;
 import com.clouway.push.shared.util.DateTime;
+import com.google.common.collect.Sets;
 import com.google.inject.util.Providers;
 import org.jmock.Expectations;
 import org.jmock.auto.Mock;
@@ -70,7 +71,7 @@ public class ActiveSubscriptionsFilterImplTest {
       oneOf(repository).findSubscriptions(event.TYPE);
       will(returnValue(subscriptionList));
 
-      oneOf(repository).removeSubscription(expiredSubscription);
+      oneOf(repository).removeSubscriptions(event.TYPE, Sets.newHashSet("peter@gmail.com"));
     }});
 
     List<Subscription> subscriptions = activeSubscriptionsFilter.filterSubscriptions(event.TYPE);


### PR DESCRIPTION
Issue #6

With this improvement were made following changes:

1 Removed unnecessary update of subscribers map when send push event to client. 
 
At current moment when user is subscribe for event then is created two references in memcache. First is subscriber with list of subscribed events and second is event with list of subscribers. 
When send push event to client then are check subscriptions for current event. If exist expired subscriptions they are removed from event reference with single update of memcache. Map of subscribers now is not changed. Only "keep alive" and "subscribe" functionality should update map of subscribers.

2 Added option for personalization of push event. 

When user want to add subscription only for himself he can add correlation id to push event so will be created separate event only for him. The api which use clouwaypush is responsible for managing of ids.
Usage: 
```
PushEventBus pushEventBus;
pushEventBus.addHandler(PushEvent.TYPE, "correlationid", new PushEventHandler() {...})
``` 
```
PushService pushService;
pushService.pushEvent(new PushEvent(),  "correlationid");
```