### PR TITLE
codec/json: add json support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,14 @@
 
   <dependencies>
 
+    <!-- JSON Support Libraries-->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.3</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- GWT -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/src/main/java/com/clouway/push/server/CurrentDate.java
+++ b/src/main/java/com/clouway/push/server/CurrentDate.java
@@ -13,5 +13,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
 @BindingAnnotation
-public @interface CurrentDate {
+@interface CurrentDate {
 }

--- a/src/main/java/com/clouway/push/server/Encoder.java
+++ b/src/main/java/com/clouway/push/server/Encoder.java
@@ -7,7 +7,14 @@ import com.clouway.push.shared.PushEvent;
  *
  * @author Georgi Georgiev (GeorgievJon@gmail.com)
  */
-public interface Encoder {
+interface Encoder {
 
+  /**
+   * Encodes the provided event as String value.
+   *
+   * @param event the event that needs to be encoded
+   * @return the encoded value of event
+   */
   String encode(PushEvent event);
+
 }

--- a/src/main/java/com/clouway/push/server/EncoderFactory.java
+++ b/src/main/java/com/clouway/push/server/EncoderFactory.java
@@ -1,0 +1,20 @@
+package com.clouway.push.server;
+
+import com.clouway.push.shared.PushEvent;
+
+/**
+ * EncoderFactory is responsible for creating of different kind of encoders depending on the event.
+ * <p/>
+ *
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+interface EncoderFactory {
+
+  /**
+   * Creates new encoder for the provided event.
+   * @param e the encoder that will be used for encoding of the event
+   * @return the newly created or existing encoder
+   */
+  Encoder create(PushEvent e);
+
+}

--- a/src/main/java/com/clouway/push/server/GenericEncoderFactory.java
+++ b/src/main/java/com/clouway/push/server/GenericEncoderFactory.java
@@ -1,0 +1,43 @@
+package com.clouway.push.server;
+
+import com.clouway.push.shared.PushEvent;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * GenericEncoderFactory is an {@link EncoderFactory} which is creating different kind of encoders depending on the event.
+ * <p/>
+ * For events which are annotated with {@link JsonEvent}, factory creates JSON encoder, where in other case it uses the default
+ * GWT-RPC encoder.
+ * <p/>
+ *
+ *
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+class GenericEncoderFactory implements EncoderFactory {
+
+  private final Encoder rpcEncoder;
+  private final Encoder jsonEncoder;
+
+  public GenericEncoderFactory(Encoder rpcEncoder,
+                               Encoder jsonEncoder) {
+
+    this.rpcEncoder = rpcEncoder;
+    this.jsonEncoder = jsonEncoder;
+  }
+
+  @Override
+  public Encoder create(PushEvent e) {
+
+    if (isJsonEvent(e)) {
+      return jsonEncoder;
+    }
+
+    return rpcEncoder;
+  }
+
+  private boolean isJsonEvent(PushEvent e) {
+    Annotation annotation = e.getClass().getAnnotation(JsonEvent.class);
+    return annotation != null;
+  }
+}

--- a/src/main/java/com/clouway/push/server/JsonEncoder.java
+++ b/src/main/java/com/clouway/push/server/JsonEncoder.java
@@ -1,0 +1,32 @@
+package com.clouway.push.server;
+
+import com.clouway.push.shared.PushEvent;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * JsonEncoder is representing JSON codec which is used by the PUSH api for sending of JSON messages to the clients.
+ * <p/>
+ *
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+class JsonEncoder implements Encoder {
+  private static final Gson gson = new GsonBuilder().create();
+
+  @Override
+  public String encode(PushEvent event) {
+    JsonElement element = gson.toJsonTree(event);
+    JsonObject jsonObject = element.getAsJsonObject();
+    jsonObject.addProperty("event", event.getAssociatedType().getKey());
+
+    // If event object has not defined TYPE property as static it will be serialised
+    // and this is removing this information from the content
+    if (jsonObject.has("TYPE")) {
+      jsonObject.remove("TYPE");
+    }
+
+    return element.toString();
+  }
+}

--- a/src/main/java/com/clouway/push/server/JsonEvent.java
+++ b/src/main/java/com/clouway/push/server/JsonEvent.java
@@ -1,0 +1,23 @@
+package com.clouway.push.server;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * JsonEvent is an annotation which is a marker for {@link com.clouway.push.shared.PushEvent} which will be serialised
+ * as JSON.
+ * <p/>
+ * For example:
+ * <pre>
+ *   {@literal @}JsonEvent
+ *   class AddPersonEvent extends PushEvent<AddPersonEventHandler>
+ * </pre>
+ *
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface JsonEvent {
+}

--- a/src/main/java/com/clouway/push/server/PushChannelModule.java
+++ b/src/main/java/com/clouway/push/server/PushChannelModule.java
@@ -65,8 +65,14 @@ public class PushChannelModule extends AbstractModule {
   }
 
   @Provides
+  @Singleton
   public Encoder getEncoder(@Named("SerializationPolicyDirectory") String serializationPolicyDirectory) {
     return new RpcEncoder(serializationPolicyDirectory);
+  }
+
+  @Provides
+  public EncoderFactory getEncoderFactory(Encoder encoder) {
+    return new GenericEncoderFactory(encoder, new JsonEncoder());
   }
 
   @Provides

--- a/src/main/java/com/clouway/push/server/PushServiceImpl.java
+++ b/src/main/java/com/clouway/push/server/PushServiceImpl.java
@@ -19,13 +19,13 @@ class PushServiceImpl implements PushService {
   private static final Logger log = Logger.getLogger(PushServiceImpl.class.getName());
 
   private final SubscriptionsRepository subscriptions;
-  private final Encoder encoder;
+  private final EncoderFactory encoderFactory;
   private final Provider<ChannelService> channelServiceProvider;
 
   @Inject
-  public PushServiceImpl(SubscriptionsRepository subscriptions, Encoder encoder, Provider<ChannelService> channelServiceProvider) {
+  public PushServiceImpl(SubscriptionsRepository subscriptions, EncoderFactory encoderFactory, Provider<ChannelService> channelServiceProvider) {
     this.subscriptions = subscriptions;
-    this.encoder = encoder;
+    this.encoderFactory = encoderFactory;
     this.channelServiceProvider = channelServiceProvider;
   }
 
@@ -35,6 +35,8 @@ class PushServiceImpl implements PushService {
 
   @Override
   public void pushEvent(PushEvent event, String correlationId) {
+    Encoder encoder = encoderFactory.create(event);
+
     String message = encoder.encode(event);
 
     // transforming the eventType

--- a/src/test/java/com/clouway/push/server/GenericEncoderFactoryTest.java
+++ b/src/test/java/com/clouway/push/server/GenericEncoderFactoryTest.java
@@ -1,0 +1,41 @@
+package com.clouway.push.server;
+
+import com.clouway.push.server.testevents.AddPersonEvent;
+import com.clouway.push.server.testevents.GenericJsonEvent;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.*;
+
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public class GenericEncoderFactoryTest {
+
+  @Rule
+  public JUnitRuleMockery context = new JUnitRuleMockery();
+
+  Encoder rpcEncoder = context.mock(Encoder.class,"rpcEncoder");
+  Encoder jsonEncoder = context.mock(Encoder.class, "jsonEncoder");
+
+  @Test
+  public void rpcEncoderIsCreated() {
+    GenericEncoderFactory factory = new GenericEncoderFactory(rpcEncoder, jsonEncoder);
+
+    Encoder encoder = factory.create(new AddPersonEvent("John",20));
+    assertThat(encoder,is(sameInstance(rpcEncoder)));
+  }
+
+  @Test
+  public void jsonEncoderIsCreated() {
+    GenericEncoderFactory factory = new GenericEncoderFactory(rpcEncoder, jsonEncoder);
+
+    Encoder encoder = factory.create(new GenericJsonEvent());
+    assertThat(encoder, is(sameInstance(jsonEncoder)));
+  }
+
+}

--- a/src/test/java/com/clouway/push/server/JsonEncoderTest.java
+++ b/src/test/java/com/clouway/push/server/JsonEncoderTest.java
@@ -1,0 +1,30 @@
+package com.clouway.push.server;
+
+import com.clouway.push.server.testevents.AddPersonEvent;
+import com.clouway.push.server.testevents.RemovePersonEvent;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public class JsonEncoderTest {
+  JsonEncoder encoder = new JsonEncoder();
+
+  @Test
+  public void happyPath() {
+    String json = encoder.encode(new AddPersonEvent("John", 12));
+    assertThat(json, is(equalTo("{\"name\":\"John\",\"age\":12,\"event\":\"addPersonEvent\"}")));
+  }
+
+  @Test
+  public void anotherEvent() {
+    String json = encoder.encode(new RemovePersonEvent(12));
+    assertThat(json, is(equalTo("{\"personId\":12,\"event\":\"removePersonEvent\"}")));
+  }
+
+}

--- a/src/test/java/com/clouway/push/server/PushServiceImplTest.java
+++ b/src/test/java/com/clouway/push/server/PushServiceImplTest.java
@@ -14,7 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class PushServiceImplTest {
 
@@ -23,6 +23,9 @@ public class PushServiceImplTest {
 
   @Mock
   private SubscriptionsRepository repository;
+
+  @Mock
+  private EncoderFactory encoderFactory;
 
   @Mock
   private Encoder encoder;
@@ -34,7 +37,7 @@ public class PushServiceImplTest {
 
   @Before
   public void setUp() throws Exception {
-    pushService = new PushServiceImpl(repository, encoder, Providers.of(channelService));
+    pushService = new PushServiceImpl(repository, encoderFactory, Providers.of(channelService));
   }
 
   @Test
@@ -47,6 +50,9 @@ public class PushServiceImplTest {
     final ArgumentCaptor<ChannelMessage> channelMessageCaptor = new ArgumentCaptor<ChannelMessage>();
 
     context.checking(new Expectations() {{
+      oneOf(encoderFactory).create(event);
+      will(returnValue(encoder));
+
       oneOf(encoder).encode(event);
       will(returnValue(eventMessage));
 
@@ -73,6 +79,9 @@ public class PushServiceImplTest {
     final ArgumentCaptor<ChannelMessage> channelMessageCaptor = new ArgumentCaptor<ChannelMessage>();
 
     context.checking(new Expectations() {{
+      oneOf(encoderFactory).create(event);
+      will(returnValue(encoder));
+
       oneOf(encoder).encode(event);
       will(returnValue(eventMessage));
 

--- a/src/test/java/com/clouway/push/server/testevents/AddPersonEvent.java
+++ b/src/test/java/com/clouway/push/server/testevents/AddPersonEvent.java
@@ -1,0 +1,28 @@
+package com.clouway.push.server.testevents;
+
+import com.clouway.push.shared.PushEvent;
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public final class AddPersonEvent extends PushEvent<AddPersonEventHandler> {
+  private static final Type<AddPersonEventHandler> TYPE = new Type<AddPersonEventHandler>("addPersonEvent");
+
+  public String name;
+  public Integer age;
+
+  public AddPersonEvent(String name, Integer age) {
+    this.name = name;
+    this.age = age;
+  }
+
+  @Override
+  public Type<AddPersonEventHandler> getAssociatedType() {
+    return TYPE;
+  }
+
+  @Override
+  public void dispatch(AddPersonEventHandler handler) {
+    handler.onPersonAdded(this);
+  }
+}

--- a/src/test/java/com/clouway/push/server/testevents/AddPersonEventHandler.java
+++ b/src/test/java/com/clouway/push/server/testevents/AddPersonEventHandler.java
@@ -1,0 +1,10 @@
+package com.clouway.push.server.testevents;
+
+import com.clouway.push.shared.PushEventHandler;
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public interface AddPersonEventHandler extends PushEventHandler {
+  void onPersonAdded(AddPersonEvent event);
+}

--- a/src/test/java/com/clouway/push/server/testevents/GenericJsonEvent.java
+++ b/src/test/java/com/clouway/push/server/testevents/GenericJsonEvent.java
@@ -1,0 +1,22 @@
+package com.clouway.push.server.testevents;
+
+import com.clouway.push.server.JsonEvent;
+import com.clouway.push.shared.PushEvent;
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+@JsonEvent
+public class GenericJsonEvent extends PushEvent<GenericJsonEventHandler> {
+  private static final Type<GenericJsonEventHandler> TYPE = new Type<GenericJsonEventHandler>("genericJsonEvent");
+
+  @Override
+  public Type<GenericJsonEventHandler> getAssociatedType() {
+    return TYPE;
+  }
+
+  @Override
+  public void dispatch(GenericJsonEventHandler handler) {
+    handler.onGenericJsonEvent(this);
+  }
+}

--- a/src/test/java/com/clouway/push/server/testevents/GenericJsonEventHandler.java
+++ b/src/test/java/com/clouway/push/server/testevents/GenericJsonEventHandler.java
@@ -1,0 +1,12 @@
+package com.clouway.push.server.testevents;
+
+import com.clouway.push.shared.PushEventHandler;
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public interface GenericJsonEventHandler extends PushEventHandler {
+
+  void onGenericJsonEvent(GenericJsonEvent event);
+
+}

--- a/src/test/java/com/clouway/push/server/testevents/RemovePersonEvent.java
+++ b/src/test/java/com/clouway/push/server/testevents/RemovePersonEvent.java
@@ -1,0 +1,27 @@
+package com.clouway.push.server.testevents;
+
+import com.clouway.push.shared.PushEvent;
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public class RemovePersonEvent extends PushEvent<RemovePersonEventHandler> {
+
+  private static final Type<RemovePersonEventHandler> TYPE = new Type<RemovePersonEventHandler>("removePersonEvent");
+
+  private final Integer personId;
+
+  public RemovePersonEvent(Integer personId) {
+    this.personId = personId;
+  }
+
+  @Override
+  public Type<RemovePersonEventHandler> getAssociatedType() {
+    return TYPE;
+  }
+
+  @Override
+  public void dispatch(RemovePersonEventHandler handler) {
+    handler.onPersonRemoved(this);
+  }
+}

--- a/src/test/java/com/clouway/push/server/testevents/RemovePersonEventHandler.java
+++ b/src/test/java/com/clouway/push/server/testevents/RemovePersonEventHandler.java
@@ -1,0 +1,12 @@
+package com.clouway.push.server.testevents;
+
+import com.clouway.push.shared.PushEventHandler;
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public interface RemovePersonEventHandler extends PushEventHandler {
+
+  void onPersonRemoved(RemovePersonEvent event);
+
+}


### PR DESCRIPTION
JSON support was being added, so the push api could be used by any HTTP client which is using JSON for communication with the server.

To be able to use JSON, you have to mark PushEvent implementations with @JsonEvent annotation.

Fixes #8