### PR TITLE
subscriptions: faster and cheaper subscription updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <appengine.version>1.9.18</appengine.version>
+    <appengine.version>1.9.30</appengine.version>
   </properties>
 
   <dependencies>
@@ -111,6 +111,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <version>2.4</version>
         <executions>
           <execution>
             <id>attach-sources</id>

--- a/src/main/java/com/clouway/push/server/PushChannelServiceImpl.java
+++ b/src/main/java/com/clouway/push/server/PushChannelServiceImpl.java
@@ -10,7 +10,6 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 
-import java.util.List;
 import java.util.logging.Logger;
 
 import static com.clouway.push.server.Subscription.aNewSubscription;
@@ -47,10 +46,10 @@ class PushChannelServiceImpl extends RemoteServiceServlet implements PushChannel
     log.info("Subscribe: " + subscriber + " for event: " + type.getKey());
 
     Subscription subscription = aNewSubscription().eventName(type.getKey())
-                                                  .eventType(type)
-                                                  .subscriber(subscriber)
-                                                  .expires(expirationDate.get())
-                                                  .build();
+            .eventType(type)
+            .subscriber(subscriber)
+            .expires(expirationDate.get())
+            .build();
 
     subscriptionsRepository.put(subscription);
   }
@@ -64,13 +63,7 @@ class PushChannelServiceImpl extends RemoteServiceServlet implements PushChannel
   @Override
   public void keepAlive(String subscriber) {
 
-    log.info("Keep alive subscriber: " + subscriber);
-
-    List<Subscription> subscriptions = subscriptionsRepository.findSubscriptions(subscriber);
-    for (Subscription subscription : subscriptions) {
-      subscription.renewingTillDate(expirationDate.get());
-      subscriptionsRepository.put(subscription);
-    }
+    subscriptionsRepository.keepAliveTill(subscriber, expirationDate.get());
   }
 
   @Override

--- a/src/main/java/com/clouway/push/server/SubscriptionsRepository.java
+++ b/src/main/java/com/clouway/push/server/SubscriptionsRepository.java
@@ -1,6 +1,7 @@
 package com.clouway.push.server;
 
 import com.clouway.push.shared.PushEvent;
+import com.clouway.push.shared.util.DateTime;
 
 import java.util.List;
 import java.util.Set;
@@ -14,11 +15,7 @@ public interface SubscriptionsRepository {
 
   void removeSubscriptions(PushEvent.Type type, Set<String> subscribers);
 
-  List<Subscription> findSubscriptions(String subscriber);
-
   List<Subscription> findSubscriptions(PushEvent.Type type);
 
-  void removeSubscription(Subscription subscription);
-
-  void removeAllSubscriptions(String subscriber);
+  void keepAliveTill(String subscriber, DateTime dateTime);
 }

--- a/src/main/java/com/clouway/push/server/UpdateFailedException.java
+++ b/src/main/java/com/clouway/push/server/UpdateFailedException.java
@@ -1,0 +1,12 @@
+package com.clouway.push.server;
+
+/**
+ *
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public class UpdateFailedException extends RuntimeException {
+
+  public UpdateFailedException(String msg) {
+    super(msg);
+  }
+}

--- a/src/test/java/com/clouway/push/server/PushChannelServiceImplTest.java
+++ b/src/test/java/com/clouway/push/server/PushChannelServiceImplTest.java
@@ -85,18 +85,10 @@ public class PushChannelServiceImplTest {
     subscriptions.add(subscription);
 
     context.checking(new Expectations() {{
-      oneOf(repository).findSubscriptions(subscriber);
-      will(returnValue(subscriptions));
-
-      oneOf(repository).put(subscription);
+      oneOf(repository).keepAliveTill(subscriber, subscriptionsExpirationDate);
     }});
 
     pushChannelService.keepAlive(subscriber);
-
-    assertThat(subscription.getExpirationDate(), is(subscriptionsExpirationDate));
-  }
-
-  private class SimpleEventHandler implements PushEventHandler {
   }
 
   private class SimpleEvent extends PushEvent<PushEventHandler> {


### PR DESCRIPTION
All subscriptions updates are now performed faster and cheaper. Here is the complete list of changes that are performed:
 * using of single bulk get/set instead of get/set/get/set
 * atomic operations for all cache operations
 * faster notifications

Keep Alive Before
![screen shot 2016-01-04 at 9 23 42 pm](https://cloud.githubusercontent.com/assets/209223/12116448/8a06ef86-b3c2-11e5-84b8-9d8e4c95f4c8.png)

![screen shot 2016-01-04 at 9 24 39 pm](https://cloud.githubusercontent.com/assets/209223/12116462/a75eb5e6-b3c2-11e5-85d2-1b5d0f537bdb.png)

Keep Alive Now 
![screen shot 2016-01-04 at 9 23 55 pm](https://cloud.githubusercontent.com/assets/209223/12116451/922a1968-b3c2-11e5-86d7-e2e2562616fb.png)

![screen shot 2016-01-04 at 9 24 07 pm](https://cloud.githubusercontent.com/assets/209223/12116456/9c06ebaa-b3c2-11e5-9c7d-dcd6c8adfcb8.png)