### PR TITLE
pushapi: subscriptions lookup performance improvement

### DIFF
--- a/src/main/java/com/clouway/push/server/MemcacheSubscriptionsRepository.java
+++ b/src/main/java/com/clouway/push/server/MemcacheSubscriptionsRepository.java
@@ -91,21 +91,16 @@ class MemcacheSubscriptionsRepository implements SubscriptionsRepository {
     log.info("Event type: " + type.getKey());
 
     final DateTime now = currentDate.get();
-    Map<String, Subscription> subscriptions = safeStoreOrUpdate(type.getKey(),
-            new Function<Map<String, Subscription>, Map<String, Subscription>>() {
 
-              @Override
-              public Map<String, Subscription> apply(Map<String, Subscription> subscriptions) {
+    Map<String, Subscription> subscriptions = (Map<String, Subscription>) memcacheService.get(type.getKey());
 
-                for (Entry<String, Subscription> each : subscriptions.entrySet()) {
-                  if (!each.getValue().isActive(now)) {
-                    subscriptions.remove(each.getKey());
-                  }
-                }
+    for (Entry<String, Subscription> each : subscriptions.entrySet()) {
 
-                return subscriptions;
-              }
-            });
+      // Keep alive ensures that these entries will be deleted.
+      if (!each.getValue().isActive(now)) {
+        subscriptions.remove(each.getKey());
+      }
+    }
 
     return Lists.newArrayList(subscriptions.values());
   }


### PR DESCRIPTION
The subscription lookup (findSubscriptions(event)) no longer makes cache updates which improves and the performance. The keep alive ensure that expired subscriptions will be deleted, so this update is not required as code is filtering the expired subscriptions.