### PR TITLE
backend: fix hardcoded service_account_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Clouway Push library is used server to send updates to the clients.
 
-##Usage
+## Usage
 ### Setup
 Include the firebase web init snippet setup in your app
 ``` in index.html

--- a/src/main/java/com/clouway/push/adapter/token/FirebaseTokenGenerator.java
+++ b/src/main/java/com/clouway/push/adapter/token/FirebaseTokenGenerator.java
@@ -52,8 +52,8 @@ public class FirebaseTokenGenerator implements TokenGenerator {
               .claim("iat", timeSeconds)
               .claim("exp", expSeconds)
               .claim("aud", IDENTITY_ENDPOINT)
-              .claim("iss", "firebase-adminsdk-9mfr3@clouwaytestapp.iam.gserviceaccount.com")
-              .claim("sub", "firebase-adminsdk-9mfr3@clouwaytestapp.iam.gserviceaccount.com")
+              .claim("iss", googleCredential.getServiceAccountId())
+              .claim("sub", googleCredential.getServiceAccountId())
               .signWith(SignatureAlgorithm.RS256, googleCredential.getServiceAccountPrivateKey())
               .compact();
     }


### PR DESCRIPTION
When create custom token is used hardcoded service account id.

Now service account id is get from google credentials.